### PR TITLE
Optimize select iterator

### DIFF
--- a/src/Iterators/DuplicateRemoverIterator.class.st
+++ b/src/Iterators/DuplicateRemoverIterator.class.st
@@ -14,8 +14,7 @@ Class {
 
 { #category : #accessing }
 DuplicateRemoverIterator >> buildInternalIterator [
-	^ [ :item | seen add: item ] doIt
-			decoratedBy: [ :item | seen includes: item ] rejectIt
+	^ [ :item | seen add: item ] doIt outputTo: [ :item | seen includes: item ] rejectIt
 ]
 
 { #category : #initialization }

--- a/src/Iterators/DuplicateRemoverIterator.class.st
+++ b/src/Iterators/DuplicateRemoverIterator.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #accessing }
 DuplicateRemoverIterator >> buildInternalIterator [
-	^ [ :item | seen add: item ] doIt outputTo: [ :item | seen includes: item ] rejectIt
+	^ [ :item | seen includes: item ] rejectIt outputTo: [ :item | seen add: item ] doIt
 ]
 
 { #category : #initialization }

--- a/src/Iterators/SelectIterator.class.st
+++ b/src/Iterators/SelectIterator.class.st
@@ -7,29 +7,42 @@ Class {
 	#superclass : #IteratorDecorator,
 	#traits : 'TIteratorDecoratorWithBlock',
 	#classTraits : 'TIteratorDecoratorWithBlock classTrait',
+	#instVars : [
+		'next'
+	],
 	#category : #'Iterators-Decorators'
 }
 
 { #category : #testing }
 SelectIterator >> hasNext [
+	next ifNotNil: [ ^ true ].
 	[ 
 		self decoratedIterator hasNext
-			ifFalse: [ ^false ].
-		self block value: self decoratedIterator peek
-	] whileFalse: [ 
-		"While select block does not return true, we ignore input of decorated iterator."
-		self decoratedIterator next ].
+			ifFalse: [
+				next := nil.
+				^false ].
+		self block value: (next := self decoratedIterator next)
+	] whileFalse.
 	^ true
 ]
 
 { #category : #accessing }
 SelectIterator >> next [
+	next ifNotNil: [ 
+		|toReturn|
+		toReturn := next.
+		next := nil.
+		^ toReturn ].
+	
 	self checkHasNext.
-	^ super next
+	^ self next
 ]
 
 { #category : #accessing }
 SelectIterator >> peek [
+	next ifNotNil: [ 
+		^ next ].
+	
 	self checkHasNext.
-	^ super peek
+	^ self peek
 ]


### PR DESCRIPTION
Modified SelectIterator to make it more efficient.

Bench scripts:

```Smalltalk
[(1 to: 100000) iterator |    [ :a | a * 2 ] collectIt
| [ :a | a even ] selectIt
| [ :a | a * 2 ] collectIt
| #even selectIt
| [ :a | a * 2 ] collectIt
| #even selectIt
| [ :a | a * 2 ] collectIt
| #even selectIt
> Array] bench.
 "'24.108 per second'"
```

```Smalltalk
[(((((1 to: 100000) collect:    [ :a | a * 2 ] thenSelect: [ :a | a even ])
collect: [:a | a*2] thenSelect: #even)
collect: [:a | a*2] thenSelect: #even)
collect: [:a | a*2] thenSelect: #even)] bench.  "'13.189 per second'"
```