### PR TITLE
20-Order-of-Iterators-it-not-preserved

### DIFF
--- a/src/Iterators-Decorators-Tests/PostActionIteratorTest.class.st
+++ b/src/Iterators-Decorators-Tests/PostActionIteratorTest.class.st
@@ -1,0 +1,33 @@
+"
+A PostActionIteratorTest is a test class for testing the behavior of PostActionIterator
+"
+Class {
+	#name : #PostActionIteratorTest,
+	#superclass : #IteratorDecoratorTest,
+	#category : #'Iterators-Decorators-Tests'
+}
+
+{ #category : #'iterator creation' }
+PostActionIteratorTest >> createIteratorOn: anIterator [
+	^ (PostActionIterator decorate: anIterator)
+			block: [ :x | 42 ]; "Result of the block is discarded."
+			yourself
+]
+
+{ #category : #accessing }
+PostActionIteratorTest >> iteratorWalk [
+	^ #(1 2 3 4 5 6 7 8 9 10)
+]
+
+{ #category : #tests }
+PostActionIteratorTest >> testExectionOrder [
+	| order |
+	order := OrderedCollection new.
+	iterator := (self objectToWalk
+						outputTo: (PostActionIterator block: [ :x | order add: 1 ]))
+						outputTo: (PostActionIterator block: [ :x | order add: 2 ]).
+	
+	iterator upToEndDiscardingResult.
+	
+	self assertCollection: order asArray equals: #(1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2)
+]

--- a/src/Iterators-Decorators-Tests/PreActionIteratorTest.class.st
+++ b/src/Iterators-Decorators-Tests/PreActionIteratorTest.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #PreActionIteratorTest,
+	#superclass : #IteratorDecoratorTest,
+	#category : #'Iterators-Decorators-Tests'
+}
+
+{ #category : #'iterator creation' }
+PreActionIteratorTest >> createIteratorOn: anIterator [
+	^ (PreActionIterator decorate: anIterator)
+			block: [ :x | 42 ]; "Result of the block is discarded."
+			yourself
+]
+
+{ #category : #accessing }
+PreActionIteratorTest >> iteratorWalk [
+	^ #(1 2 3 4 5 6 7 8 9 10)
+]
+
+{ #category : #tests }
+PreActionIteratorTest >> testExectionOrder [
+	| order |
+	order := OrderedCollection new.
+	iterator := (self objectToWalk
+						outputTo: (PreActionIterator block: [ :x | order add: 1 ]))
+						outputTo: (PreActionIterator block: [ :x | order add: 2 ]).
+	
+	iterator upToEndDiscardingResult.
+	
+	self assertCollection: order asArray equals: #(2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1)
+]

--- a/src/Iterators-Decorators/IteratorDecoratorFactory.class.st
+++ b/src/Iterators-Decorators/IteratorDecoratorFactory.class.st
@@ -23,7 +23,7 @@ IteratorDecoratorFactory class >> detectIteratorFor: aValuable [
 
 { #category : #factory }
 IteratorDecoratorFactory class >> doIteratorFor: aValuable [
-	^ PreActionIterator new
+	^ PostActionIterator new
 			block: aValuable;
 			yourself
 ]

--- a/src/Iterators-Decorators/PostActionIterator.class.st
+++ b/src/Iterators-Decorators/PostActionIterator.class.st
@@ -9,9 +9,11 @@ Class {
 
 { #category : #accessing }
 PostActionIterator >> next [
-	| toReturn |
-	toReturn := super next.
 	self shouldApplyActionOnNext
-		ifTrue: self block.
-	^ toReturn
+		ifTrue: [ 
+			| toReturn |
+			self block value: (toReturn := super next).
+			^ toReturn ].
+	
+	^ super next
 ]


### PR DESCRIPTION
By defaut, the doIterator should be a PostActionIterator.
Indeed, this is the natural execution expected.

Fix #20 