### PR TITLE
26-Create-a-simpler-ActionIterator

### DIFF
--- a/src/Iterators-Decorators-Tests/ActionIteratorTest.class.st
+++ b/src/Iterators-Decorators-Tests/ActionIteratorTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #ActionIteratorTest,
+	#superclass : #IteratorDecoratorTest,
+	#category : #'Iterators-Decorators-Tests'
+}
+
+{ #category : #'iterator creation' }
+ActionIteratorTest >> createIteratorOn: anObject [
+	^ (ActionIterator decorate: anObject)
+		block: [ :x | 42 ]; "Result of the block is discarded"
+		yourself
+]
+
+{ #category : #accessing }
+ActionIteratorTest >> iteratorWalk [
+	^ #(1 2 3 4 5 6 7 8 9 10)
+]

--- a/src/Iterators-Decorators/ActionIterator.class.st
+++ b/src/Iterators-Decorators/ActionIterator.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #accessing }
 ActionIterator >> next [
-	| toReturn |
-	self block value: (toReturn := super next).
-	^ toReturn
+	^ super next in: [ :next |
+		self block value: next.
+		next ]
 ]

--- a/src/Iterators-Decorators/ActionIterator.class.st
+++ b/src/Iterators-Decorators/ActionIterator.class.st
@@ -1,0 +1,17 @@
+"
+I am an iterator that perform an action on incoming objects (execute my #block with the object provided as argument), discard the result of the action and return that incoming object.
+"
+Class {
+	#name : #ActionIterator,
+	#superclass : #IteratorDecorator,
+	#traits : 'TIteratorDecoratorWithBlock',
+	#classTraits : 'TIteratorDecoratorWithBlock classTrait',
+	#category : #'Iterators-Decorators-Decorators'
+}
+
+{ #category : #accessing }
+ActionIterator >> next [
+	| toReturn |
+	self block value: (toReturn := super next).
+	^ toReturn
+]

--- a/src/Iterators-Decorators/IteratorDecoratorFactory.class.st
+++ b/src/Iterators-Decorators/IteratorDecoratorFactory.class.st
@@ -23,7 +23,7 @@ IteratorDecoratorFactory class >> detectIteratorFor: aValuable [
 
 { #category : #factory }
 IteratorDecoratorFactory class >> doIteratorFor: aValuable [
-	^ PostActionIterator new
+	^ ActionIterator new
 			block: aValuable;
 			yourself
 ]


### PR DESCRIPTION
Created ActionIterator.Now #doIteratorFor: returns an instance of ActionIterator.Fix #26.